### PR TITLE
mlflow fix use of /Shared/ and 'project' so it works with Databricks (but doesn't complain of non-writeable local paths)

### DIFF
--- a/ultralytics/yolo/utils/callbacks/git_tags.py
+++ b/ultralytics/yolo/utils/callbacks/git_tags.py
@@ -1,0 +1,126 @@
+"""in this file we have the simple function
+
+```python
+repository_tags(*args, **kwargs) -> dict[str, str]
+```
+
+please take a look at it's docstring for usage
+
+Motivation
+----------
+
+We at Scenera log our training runs with specific tags to keep track of the source used to train
+
+```json
+{
+    "git-branch": "add_mlflow",
+    "git-hash": "8077f7c47bc1ccc592187374a4bd5c967483910b",
+    "git-origin": "git@github.com:YoRigid/scenera-yolov5.git",
+    "git-submodule-yolov5-branch": "master",
+    "git-submodule-yolov5-hash": "6e04b94fa9fb12ff66b2329660de8a5a8e5f1b1d",
+    "git-submodule-yolov5-origin": "https://github.com/ultralytics/yolov5"
+}
+```
+
+```dirtree
+
+mlruns/0/38b29ac01a244cf6b7bee13934b285cb/params
+├── artifact_alias
+├── batch_size
+├── bbox_interval
+├── cos_lr
+├── data
+├── epochs
+├── exist_ok
+├── freeze
+├── git-branch                    <---
+├── git-hash                      <---
+├── git-origin                    <---
+├── git-submodule-yolov5-branch   <---
+├── git-submodule-yolov5-hexsha   <---
+├── git-submodule-yolov5-origin   <---
+|
+```
+"""
+
+from __future__ import annotations
+from git import Repo
+
+
+class DirtyGitRepo(BaseException):
+    """Repository has modified files"""
+
+
+def repository_tags(
+    prefix: str = "git", search_parent_directories: bool = False, suppress: bool = False
+) -> dict[str, str]:
+    """Git repository tags
+
+    Fetch git information from current context
+
+    Parameters
+    ----------
+    prefix : str, optional
+        parameter prefix, by default "git"
+    search_parent_directories: bool, optional
+        search parent dirs for git repository, by default 'False',
+    suppress: bool, optional
+        suppress uncommitted changes check, by default 'False'
+
+    Returns
+    -------
+    dict[str, str]
+        current git repository information
+
+    Raises
+    ------
+    DirtyGitRepo:
+        Unstashed changes to the repository or submodule (don't make changes to the submodule)
+    InvalidGitRepositoryError:
+        GitPython Error, repository is not found
+    NoSuchPathError:
+        GitPython Error, repository is not found
+
+    Example
+    -------
+
+    >>> import json
+    >>> from git_utils import repository_tags()
+    >>> json.dumps(repository_tags(prefix="git"))
+
+    ```json
+    {
+        "git-branch": "add_mlflow",
+        "git-hash": "8077f7c47bc1ccc592187374a4bd5c967483910b",
+        "git-origin": "git@github.com:YoRigid/scenera-yolov5.git",
+        "git-submodule-yolov5-branch": "master",
+        "git-submodule-yolov5-hash": "6e04b94fa9fb12ff66b2329660de8a5a8e5f1b1d",
+        "git-submodule-yolov5-origin": "https://github.com/ultralytics/yolov5"
+    }
+    ```
+
+    """
+
+    repo = Repo(search_parent_directories=search_parent_directories)
+    if repo.is_dirty(untracked_files=True, submodules=True) and not suppress:
+        raise DirtyGitRepo(
+            "The purpose of logging git tags is being able to repoduce. \
+            \n Please commit and push OR restore your changes"
+        )
+    prefix = prefix or "git"
+    data = {
+        f"{prefix}-branch": repo.active_branch,
+        f"{prefix}-hash": repo.head.object.hexsha,
+        f"{prefix}-origin": repo.remotes.origin.url,
+    }
+    for submodule in repo.submodules:
+        _prefix = f"{prefix}-submodule-{submodule.name}"
+        data.update(
+            {
+                f"{_prefix}-branch": submodule.branch,
+                f"{_prefix}-hash": submodule.hexsha,
+                f"{_prefix}-origin": submodule.url,
+            }
+        )
+
+    return {key: str(val) for key, val in data.items()}

--- a/ultralytics/yolo/utils/callbacks/mlflow.py
+++ b/ultralytics/yolo/utils/callbacks/mlflow.py
@@ -30,8 +30,10 @@ def on_pretrain_routine_end(trainer):
 
         experiment_name = '/Shared/' + trainer.args.project or '/Shared/YOLOv8'
     
-        while (experiment := mlflow.get_experiment_by_name(experiment_name)) is None:
-            experiment_name = mlflow.create_experiment(experiment_name)
+        experiment = mlflow.get_experiment_by_name(experiment_name)
+        if experiment is None:
+            _id = mlflow.create_experiment(experiment_name)
+            experiment = mlflow.get_experiment_by_name(_id)
 
         mlflow.set_experiment(experiment_name)
 

--- a/ultralytics/yolo/utils/callbacks/mlflow.py
+++ b/ultralytics/yolo/utils/callbacks/mlflow.py
@@ -29,7 +29,7 @@ def on_pretrain_routine_end(trainer):
         mlflow.set_tracking_uri(mlflow_location)
 
         experiment_name = '/Shared/' + trainer.args.project or '/Shared/YOLOv8'
-    
+
         experiment = mlflow.get_experiment_by_name(experiment_name)
         if experiment is None:
             mlflow.create_experiment(experiment_name)
@@ -65,7 +65,7 @@ def on_train_end(trainer):
         root_dir = Path(__file__).resolve().parents[3]
         run.log_artifact(trainer.last)
         run.log_artifact(trainer.best)
-        LOGGER.warning(f'Trying to save artifaces in {str(trainer.save_dir)}')
+        LOGGER.warning(f'Trying to save artifacts in {str(trainer.save_dir)}')
         run.pyfunc.log_model(artifact_path=experiment_name.replace("/Shared/", ""),
                              code_path=[str(root_dir)],
                              artifacts={'model_path': str(trainer.save_dir)},

--- a/ultralytics/yolo/utils/callbacks/mlflow.py
+++ b/ultralytics/yolo/utils/callbacks/mlflow.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 
 from ultralytics.yolo.utils import LOGGER, TESTS_RUNNING, colorstr
-from .git_tags import repository_tags, DirtyGitRepo
+from .git_tags import repository_tags
 
 try:
     import mlflow

--- a/ultralytics/yolo/utils/callbacks/mlflow.py
+++ b/ultralytics/yolo/utils/callbacks/mlflow.py
@@ -26,7 +26,7 @@ def on_pretrain_routine_end(trainer):
         mlflow_location = os.environ['MLFLOW_TRACKING_URI']  # "http://192.168.xxx.xxx:5000"
         mlflow.set_tracking_uri(mlflow_location)
 
-        experiment_name = trainer.args.project or '/Shared/YOLOv8'
+        experiment_name = '/Shared/' + trainer.args.project or '/Shared/YOLOv8'
         experiment = mlflow.get_experiment_by_name(experiment_name)
         if experiment is None:
             mlflow.create_experiment(experiment_name)
@@ -58,7 +58,8 @@ def on_train_end(trainer):
         root_dir = Path(__file__).resolve().parents[3]
         run.log_artifact(trainer.last)
         run.log_artifact(trainer.best)
-        run.pyfunc.log_model(artifact_path=experiment_name,
+        LOGGER.warning(f'Trying to save artifaces in {str(trainer.save_dir)}')
+        run.pyfunc.log_model(artifact_path=experiment_name.replace("/Shared/", ""),
                              code_path=[str(root_dir)],
                              artifacts={'model_path': str(trainer.save_dir)},
                              python_model=run.pyfunc.PythonModel())

--- a/ultralytics/yolo/utils/callbacks/mlflow.py
+++ b/ultralytics/yolo/utils/callbacks/mlflow.py
@@ -32,8 +32,8 @@ def on_pretrain_routine_end(trainer):
     
         experiment = mlflow.get_experiment_by_name(experiment_name)
         if experiment is None:
-            _id = mlflow.create_experiment(experiment_name)
-            experiment = mlflow.get_experiment_by_name(_id)
+            mlflow.create_experiment(experiment_name)
+            experiment = mlflow.get_experiment_by_name(experiment_name)
 
         mlflow.set_experiment(experiment_name)
 


### PR DESCRIPTION
This allow logging to a Databricks hosted MLflow server.

Without this fix:

- if you set project='/Shared/myYOLOv8' you will receive an error that the local path '/Shared/myYOLOv8' is not writeable.
- if you set project='myYOLOv8' then Databricks REST API will complain that you need a path with '/Users' (or '/Shared' would work too).
- the artifacts path needs to have /Shared removed because artifacts paths must always be relative.

NOTE: We'll probably want to get these fixes merged back into the mainline at some point.